### PR TITLE
History登録APIの完成

### DIFF
--- a/backend/src/controllers/history.go
+++ b/backend/src/controllers/history.go
@@ -1,0 +1,36 @@
+package controllers
+
+import (
+	"net/http"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+	"github.com/y-watagashi/MoneyCraft/models"
+)
+
+type HistoryHandler struct {
+	Db *gorm.DB
+}
+
+// Historyの新規作成と保存
+func (h *HistoryHandler) AddHistory(c *gin.Context) {
+    // ユーザーの検索
+	var user models.User
+	err := h.Db.First(&user, c.Param("id")).Error; if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "User not found"})
+		return
+	}
+
+	// 新しいHistoryレコードの作成
+	history := models.History{
+		UserID: user.ID,
+		Amount: user.Currency,
+	}
+
+	// Historyレコードの保存
+	if err := h.Db.Create(&history).Error; err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "Error saving history"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "ok", "history": history})
+}

--- a/backend/src/main.go
+++ b/backend/src/main.go
@@ -17,8 +17,14 @@ func main() {
     }
 
 	userHandler := controllers.UserHandler{Db: db}
+	historyHandler := controllers.HistoryHandler{Db: db}
+
+	// User関連のエンドポイント
 	r.POST("/user", userHandler.AddUser)
 	r.GET("/user/:id", userHandler.GetUser)
+
+	// History関連のエンドポイント
+	r.POST("/history/:id", historyHandler.AddHistory)
 	
 	r.Run("0.0.0.0:8000") // listen and serve on
 }

--- a/backend/src/models/History.go
+++ b/backend/src/models/History.go
@@ -8,5 +8,5 @@ type History struct {
 	gorm.Model
 	UserID uint
 	User User `gorm:"foreignKey:UserID; references:ID"`
-	Amount string `json:"amount" binding:"required"`
+	Amount int `json:"amount" binding:"required"`
 }

--- a/backend/src/models/User.go
+++ b/backend/src/models/User.go
@@ -10,7 +10,7 @@ type User struct {
 	Email string `json:"email" binding:"required"`
 	Password string `json:"password" binding:"required"`
 	IsParent bool `json:"isParent" binding:"required"`
-	currency int `json:"currency" binding:"required"`
+	Currency int `json:"currency" binding:"required"`
 	FamilyID uint
 }
 


### PR DESCRIPTION
## 概要

UserテーブルとHistoryテーブルの改修
Historyの登録APIの作成

## 変更点

- Userテーブルのcurrency→Currencyに修正
- HistoryテーブルのAmountフィールドのデータ型をstring→intに修正
- controllersフォルダにhistory.goファイルを作成
- controllers/history.goにて、Historyの新規作成と保存を行うAddHistory関数を作成

## 影響範囲

UserとHistoryに関する機能

## テスト

- ID1のユーザーのCurrencyを変更しつつHistoryの登録を行い、正常にデータベースに登録されることを確認しました。


